### PR TITLE
Fix deprecated artifact action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           php -d extension=chronos ./vendor/bin/pest ide-stubs/tests
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: extension
           path: ext/modules/chronos.so


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in the build workflow

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca288f7c0833095042934422b53e8