### PR TITLE
Fix Pest config path in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         if: success()
         run: |
           composer install
-          php -d extension=chronos ./vendor/bin/pest ide-stubs/tests
+          php -d extension=chronos ./vendor/bin/pest --configuration ide-stubs/phpunit.xml.dist
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix the path to the phpunit configuration in the GitHub Actions workflow

## Testing
- `composer install`
- `php -d extension=chronos vendor/bin/pest --configuration ide-stubs/phpunit.xml.dist` *(fails: Unable to load dynamic library 'chronos')*

------
https://chatgpt.com/codex/tasks/task_e_686ca3eec9708330aabb515b9b95f536