### PR TITLE
Add Docker build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:8.3-cli-alpine
+
+RUN apk add --no-cache --virtual .build-deps \
+        autoconf gcc g++ make \
+        php8-dev linux-headers \
+    && docker-php-source extract
+
+COPY ./ext /usr/src/php/ext/chronos
+
+RUN cd /usr/src/php/ext/chronos \
+    && phpize \
+    && ./configure \
+    && make -j$(nproc) \
+    && make install
+
+COPY ./php.ini /usr/local/etc/php/conf.d/chronos.ini
+
+RUN docker-php-source delete && apk del .build-deps
+
+CMD ["php", "-a"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ sudo make install
 extension=chronos.so
 ```
 
+## Building with Docker
+
+```bash
+docker build -t chronos-ext .
+# Build using the provided Dockerfile and php.ini
+```
+
+You can then run:
+
+```bash
+docker run --rm chronos-ext php -m | grep chronos
+```
+
 ## Usage
 
 ```php
@@ -48,4 +61,5 @@ pecl package
 ```
 
 This will generate a distributable `chronos-0.0.1.tgz` archive that can be uploaded to PECL.
+
 

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,1 @@
+extension=chronos.so


### PR DESCRIPTION
## Summary
- provide Dockerfile and php.ini to build the Chronos extension in a container
- document Docker build instructions

## Testing
- `docker build -t chronos-ext .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc81e341c8330861b0745c6d76395